### PR TITLE
logging, test videos, video unavailable

### DIFF
--- a/UserScrape/.vscode/extensions.json
+++ b/UserScrape/.vscode/extensions.json
@@ -1,17 +1,13 @@
 {
 	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"Azurite.azurite",
 		"ms-azuretools.vscode-azurestorage",
 		"ms-python.python",
-		"formulahendry.code-runner",
 		"njpwerner.autodocstring"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+	"unwantedRecommendations": []
 }

--- a/UserScrape/.vscode/launch.json
+++ b/UserScrape/.vscode/launch.json
@@ -2,11 +2,7 @@
   "configurations": [
     {
       "name": "start experiment",
-      "args": [
-        "--init",
-        "-a",
-        "0"
-      ],
+      "args": [],
       "type": "python",
       "request": "launch",
       "program": "app.py",

--- a/UserScrape/.vscode/settings.json
+++ b/UserScrape/.vscode/settings.json
@@ -6,6 +6,9 @@
         "creds",
         "dotenv",
         "getenv",
+        "groupby",
+        "iterrows",
+        "nargs",
         "spawnl",
         "strftime"
     ],

--- a/UserScrape/app.py
+++ b/UserScrape/app.py
@@ -1,61 +1,76 @@
 import os
 from cfg import load_cfg
 from crawler import Crawler
-from selenium.common.exceptions import NoSuchElementException
-from data import load_all_seeds, seeds_for_user
+from selenium.common.exceptions import NoSuchElementException, WebDriverException
+from data import load_seed_videos, load_test_videos
 import asyncio
 import argparse
 from typing import List
 from store import BlobStore
 from azure.storage.blob import PublicAccess
 from discord_bot import DiscordBot
+import logging
+from log import configure_log
+import time
+import seqlog
+from cfg import UserCfg
+import shortuuid
 
 
-async def experiment(initialization: bool, accounts: List[int]):
+async def experiment(initialization: bool, accounts: List[str]):
+
+    # cfg
     cfg = load_cfg()
-    video_seeds_df = load_all_seeds()
 
-    cfg = load_cfg()
-    if initialization:
-        video_seeds_df = load_all_seeds()
-    else:
-        # todo: function that returns only 5 sampled videos
-        video_seeds_df = load_all_seeds()[0:5]
+    experiment_id = shortuuid.random(8)
+    configure_log(cfg.seqUrl, experiment_id=experiment_id)
 
-    repetitions = 2  # 100
-    # todo: this list of videos needs to be sampled
-    test_videos = ['uo9dAIQR3g8', 'CH50zuS8DD0', '9_R3_CThc38']
+    log = logging.getLogger('seq')
+    users: List[UserCfg] = [u for u in cfg.users if accounts == None or u.ideology in accounts]
 
+    log.info("Experiment started. Init={initialization}, Accounts={accounts}",
+             initialization=initialization, accounts='|'.join([user.email for user in users]))
+
+    videos_to_test = load_test_videos()
+    videos_to_seed = load_seed_videos(50 if initialization else 5)
+
+    # env
     store = BlobStore(cfg.data_storage_cs, 'userscrape')
     store.ensure_exits(PublicAccess.Container)
-
     bot = DiscordBot(cfg.discord)
     await bot.start_in_backround()
 
     try:
-        for user in [cfg.users[i] for i in accounts]:
-            print(f'scraping for user {user.email}')
-            crawler = Crawler(store, bot, user, cfg.headless)
-            # crawler.test_ip()
+        for user in users:
+            log.info('{email} - started scraping', email=user.email)
+            start = time.time()
 
-            user_seed_videos = seeds_for_user(user, video_seeds_df)
+            crawler = Crawler(store, bot, user, cfg.headless, log)
+            user_seed_videos = videos_to_seed[user.ideology]
+            user_seed_video_ids: List[str] = [video.video_id for video in user_seed_videos]
 
             try:
-                # crawler.load_home_and_login()
-                await crawler.login()
+                await crawler.load_home_and_login()
+                log.info("{email} - logged in", email=user.email)
                 crawler.delete_history()
-                for repetition in range(1, repetitions):
-                    await crawler.watch_videos([video.video_id for video in user_seed_videos[0:5]])
-                    crawler.scan_feed()
-                    # 115 test videos
-                    for video in test_videos:
-                        crawler.get_recommendations_for_video(video)
-                        crawler.delete_last_video_from_history(video)
-                    crawler.delete_history()
-                    crawler.update_trial()
-                    crawler.shutdown()
-            except NoSuchElementException as e:
-                print(f'Not able to find a required element {e.msg}. {user.email}')
+
+                log.info("{email} - seeding with {videos}", email=user.email, videos='|'.join(user_seed_video_ids))
+                await crawler.watch_videos(user_seed_video_ids)
+                crawler.scan_feed()
+
+                log.info("{email} - collecting recommendations for {video_number} videos",
+                         email=user.email, videos=len(videos_to_test))
+                for video in videos_to_test:
+                    crawler.get_recommendations_for_video(video.video_id)
+                    crawler.delete_last_video_from_history(video.video_id)
+                crawler.delete_history()
+                crawler.update_trial()
+                crawler.shutdown()
+
+                log.info("{email} - complete in {duration}s", email=user.email, duration=time.time() - start)
+
+            except BaseException:
+                log.error('{email} - unhandled error. aborting scraping for this user', email=user.email, exc_info=1)
             finally:
                 crawler.shutdown()
     finally:
@@ -63,34 +78,31 @@ async def experiment(initialization: bool, accounts: List[int]):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Start one iteration of the experiment. If you run this for the first time \
-        set --init. If you do not want to run the experiment with all accounts, specifiy the list with --accounts')
+        set --init. If you do not want to run the experiment with all accounts, specify the list with --accounts')
     parser.add_argument("--init", "-i",
                         help="Provide this argument if the experiment shall start from the beginning. Each account will start with a clear history and will watch 50 initial videos",
                         action='store_true')
     parser.add_argument("--accounts", "-a",
-                        help="A list of numbers for which the corresponding accounts will be included in this run of the experiment. \
+                        help="A | separeted list users for which the corresponding accounts will be included in this run of the experiment. \
      Possible options are \n \
-        0. White Identitarian \n \
-        1. MRA \n \
-        2. Conspiracy \n \
-        3. Libertarian \n \
-        4. Provocative Anti-SJW \n \
-        5. Anti-SJW \n \
-        6. Socialist \n \
-        7. Religious Conservative \n \
-        8. Social Justice \n \
-        9. Center/Left MSM \n \
-        10. Partisan Left \n \
-        11. Partisan Right \n \
-        12. Anti-Theist \n \
-        13. Uniform (An equal number of videos from each class) \n \
-        14. Videos are watched proportional to their Viewcount \n \
-        15. Non-Political (Non-political videos) \n \
-        16. A fresh account without viewing history ",
-                        default=list(range(0, 17)),
-                        nargs="+", type=int,
-                        choices=list(range(0, 17))
-                        )
+        White Identitarian \n \
+        MRA \n \
+        Conspiracy \n \
+        Libertarian \n \
+        Provocative Anti-SJW \n \
+        Anti-SJW \n \
+        Socialist \n \
+        Religious Conservative \n \
+        Social Justice \n \
+        Center/Left MSM \n \
+        Partisan Left \n \
+        Partisan Right \n \
+        Anti-Theist \n \
+        Uniform (An equal number of videos from each class) \n \
+        Proportional (Videos are watched proportional to their Viewcount) \n \
+        Non-Political (Non-political videos) \n \
+        Fresh (a fresh account without viewing history)",
+                        default=None)
     args = parser.parse_args()
 
-    asyncio.run(experiment(args.init, args.accounts))
+    asyncio.run(experiment(args.init, args.accounts.split('|') if args.accounts else None))

--- a/UserScrape/cfg.py
+++ b/UserScrape/cfg.py
@@ -6,6 +6,7 @@ from dataclasses_json import dataclass_json
 from dataclasses_jsonschema import JsonSchemaMixin, SchemaType
 from dataclasses_jsonschema.type_defs import JsonSchemaMeta
 
+
 @dataclass_json
 @dataclass
 class UserCfg(JsonSchemaMixin):
@@ -29,13 +30,16 @@ class UserCfg(JsonSchemaMixin):
             "Conspiracy",
             "Social Justice"
         ]}))
-    notify_discord_user_id:Optional[int] = field(metadata=JsonSchemaMeta({"description": "the user id (e.g. 123465448467005488) in discord to notify", "required": False }))
+    notify_discord_user_id: Optional[int] = field(metadata=JsonSchemaMeta(
+        {"description": "the user id (e.g. 123465448467005488) in discord to notify", "required": False}))
+
 
 @dataclass_json
 @dataclass
 class DiscordCfg(JsonSchemaMixin):
-    bot_token:str = field(metadata={"description": "The auth token for the discord bot"})
-    channel_id:int  = field(metadata={"description":"The channel to ask for user validation codes"})
+    bot_token: str = field(metadata={"description": "The auth token for the discord bot"})
+    channel_id: int = field(metadata={"description": "The channel to ask for user validation codes"})
+
 
 @dataclass_json
 @dataclass
@@ -55,7 +59,11 @@ class Cfg(JsonSchemaMixin):
                            "description": "When true, selenium will run without an interactive browser showing. Must be true when running in a container"})
 
     discord: DiscordCfg = field(metadata={
-                                 "description": "configuration for the discord bot used to request user validation"})
+        "description": "configuration for the discord bot used to request user validation"})
+
+    seqUrl: str = field(metadata=JsonSchemaMeta({
+        "description": "url of your seq instance",
+        "examples": ["http://log.recfluence.net/", "http://localhost:5341/"]}))
 
 
 def load_cfg() -> Cfg:
@@ -64,3 +72,8 @@ def load_cfg() -> Cfg:
     with open('userscrape.json', "r") as r:
         cfg = Cfg.from_json(r.read())
     return cfg
+
+
+with open('./userscrape.schema.json', "w") as w:
+    schemaTxt = json.dumps(Cfg.json_schema(), indent='  ')
+    w.write(schemaTxt)

--- a/UserScrape/cfg_schema.py
+++ b/UserScrape/cfg_schema.py
@@ -1,8 +1,0 @@
-import json
-from cfg import Cfg
-
-## run this file to generate a new schema
-
-with open('./userscrape.schema.json', "w") as w:
-    schemaTxt = json.dumps(Cfg.json_schema(), indent='  ')
-    w.write(schemaTxt)

--- a/UserScrape/crawler.py
+++ b/UserScrape/crawler.py
@@ -21,16 +21,30 @@ from dataclasses import dataclass
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath, WindowsPath
 import tempfile
 import asyncio
-from typing import List
+from typing import Any, List, Dict
 from store import BlobStore
 from discord_bot import DiscordBot
 from cfg import UserCfg
+import logging
+from logging import Logger
 
 
 @dataclass
 class CrawlResult:
     success: bool = True
     res: str = None
+
+
+@dataclass
+class VideoUnavailable:
+    reason: str
+    sub_reason: str
+
+
+@dataclass
+class RecResult:
+    recs: List[Dict[str, Any]]
+    video_error: VideoUnavailable = None
 
 
 def create_driver(headless: bool) -> WebDriver:
@@ -51,13 +65,14 @@ def create_driver(headless: bool) -> WebDriver:
 
 
 class Crawler:
-    def __init__(self, store: BlobStore, bot: DiscordBot, user: UserCfg, headless: bool, lang='en'):
+    def __init__(self, store: BlobStore, bot: DiscordBot, user: UserCfg, headless: bool, log: Logger, lang='en'):
         self.store = store
         self.bot = bot
         self.driver = create_driver(headless)
         self.wait = WebDriverWait(self.driver, 10)
         self.user = user
         self.init_time = datetime.now()
+        self.log = log
         self.lang = lang
         self.trial_nr = 1
 
@@ -66,7 +81,7 @@ class Crawler:
         wd.get('https://httpbin.org/ip')
         pre: WebElement = wd.find_element_by_css_selector('pre')
         print(f'Running with IP {json.loads(pre.text)["origin"]}')
-        await self.__log_info('ip')
+        await self.__log_driver_status('ip')
 
     async def load_home_and_login(self):
         wd = self.driver
@@ -76,7 +91,7 @@ class Crawler:
 
         wd.get('https://www.youtube.com')
         self.wait_for_visible('#contents')
-        await self.__log_info('home')
+        await self.__log_driver_status('home')
 
         try:
             login = wd.find_element_by_css_selector('paper-button[aria-label="Sign in"]')
@@ -108,7 +123,7 @@ class Crawler:
         async def onHome():
             phase = 'home'
             wfv(homeSelector)
-            await self.__log_info(phase)
+            await self.__log_driver_status(phase)
             self.__save_cookies()
 
         try:
@@ -139,7 +154,6 @@ class Crawler:
                 wfc(telSelector).send_keys(code)
                 wfc('#idvanyphoneverifyNext').click()
             elif authEl.get_attribute('data-sendmethod') == 'SMS':
-                # revalidation
                 wfc(smsSelector).click()  # select sms option
                 code = await self.bot.request_code(user)
                 wfc(telSelector).send_keys(code)
@@ -156,12 +170,12 @@ class Crawler:
             return CrawlResult()
 
         except WebDriverException as e:
-            await self.__log_info(f'{phase}-exception', e.msg)
+            await self.__log_driver_status(f'{phase}-exception', e.msg)
             raise e
 
         return CrawlResult()
 
-    def get_video_features(self, videoId, recommendations: List[dict], personalized_count: int):
+    def get_video_features(self, videoId, rec_result: RecResult, personalized_count: int):
         seshPath = self.path_session()
         filename = 'output/recommendations/' + self.user.email + '_' + videoId + '_' + \
             str(self.init_time).replace(':', '-').replace(' ', '_') + '.json'
@@ -179,45 +193,71 @@ class Crawler:
             'channel_id': self.wait.until(EC.presence_of_element_located(
                 (By.CSS_SELECTOR, "#text > a"))).get_attribute('href').strip(
                 'https://www.youtube.com/channel/'),
-            'recommendations': recommendations,
-            'personalization_count': personalized_count
+            'recommendations': rec_result.recs,
+            'personalization_count': personalized_count,
+            'unavailable': rec_result.video_error
         }
 
         # upload the information as a blob
         self.store.save(seshPath / filename, video_info)
 
-    def get_recommendations_for_video(self, source):
-        self.driver.get("https://www.youtube.com/watch?v=" + source)
+    def get_recommendations_for_video(self, video_id) -> RecResult:
+        self.driver.get("https://www.youtube.com/watch?v=" + video_id)
 
         # this is the list of elements from the recommendation sidebar
         # it does not always load all recommendations at the same time, therefore the loop
         all_recs = []
+        unavalable: VideoUnavailable = None
+        findRecsEx: WebDriverException = None
         while len(all_recs) < 19:
-            all_recs = self.wait.until(
-                EC.visibility_of_all_elements_located(
-                    (By.XPATH, '//*[@id="dismissable"]/div/div[1]/a'))
-            )
+            try:
+                all_recs = self.wait.until(
+                    EC.visibility_of_all_elements_located(
+                        (By.XPATH, '//*[@id="dismissable"]/div/div[1]/a'))
+                )
+            except WebDriverException as e:
+                findRecsEx = e
+                break
 
-        recos = []
-        personalized_counter = 0  # how many of the recommendations are personalized?
-        for i in all_recs:
-            personalized = 'Recommended for you' in i.text
-            if personalized:
-                personalized_counter += 1
-            # take the link and remove everything except for the id of the video that the link leads to
-            recommendation_id = i.get_attribute('href').replace(
-                'https://www.youtube.com/watch?v=', '')
-            title = i.find_element_by_xpath('//*[@id="video-title"]').get_attribute('title')
-            full_info = i.find_element_by_xpath('//*[@id="video-title"]').get_attribute('aria-label')
-            recos.append({
-                'id': recommendation_id,
-                'personalized': personalized,
-                'title': title,
-                'full_info': full_info})
+        if findRecsEx:
+            reason: List[WebElement] = self.driver.find_elements_by_css_selector(
+                '.reason.yt-player-error-message-renderer')
+            subReason: List[WebElement] = self.driver.find_elements_by_css_selector(
+                '.subreason.yt-player-error-message-renderer')
+
+            if(reason):
+                unavalable = VideoUnavailable(reason[0].text, subReason[0].text if subReason else None)
+
+            self.__log_driver_status('recommendations', findRecsEx.msg)
+            raise findRecsEx
+
+        recs = []
+        if unavalable == None:
+            personalized_counter = 0  # how many of the recommendations are personalized?
+            for i in all_recs:
+                personalized = 'Recommended for you' in i.text
+                if personalized:
+                    personalized_counter += 1
+                # take the link and remove everything except for the id of the video that the link leads to
+                recommendation_id = i.get_attribute('href').replace(
+                    'https://www.youtube.com/watch?v=', '')
+                title = i.find_element_by_xpath('//*[@id="video-title"]').get_attribute('title')
+                full_info = i.find_element_by_xpath('//*[@id="video-title"]').get_attribute('aria-label')
+                recs.append({
+                    'video_id': video_id,
+                    'id': recommendation_id,
+                    'personalized': personalized,
+                    'title': title,
+                    'full_info': full_info})
+
+        rec_result = RecResult(recs, unavalable)
+
         # store the information about the current video plus the corresponding recommendations
-        self.get_video_features(source, recos, personalized_counter)
+        self.get_video_features(video_id, rec_result, personalized_counter)
+
+        self.log.info('{email} - recommendations collected for {video}', email=self.user.email, video=video_id)
         # return the recommendations
-        return recos
+        return rec_result
 
     def delete_last_video_from_history(self, video_id: str):
         self.driver.get('https://www.youtube.com/feed/history')
@@ -296,6 +336,9 @@ class Crawler:
             EC.presence_of_element_located((By.XPATH,
                                             '//*[@class="ytp-play-button ytp-button"]'))
         )
+
+        self.log.info('{email} - started watching video {video}', email=self.user.email, video=videoId)
+
         # todo: in the end this will be only english
         if playbutton.get_attribute('title') in ["Play (k)", "Wiedergabe (k)"]:
             playbutton.click()
@@ -305,28 +348,21 @@ class Crawler:
         advertisements = {videoId: []}
         filename = 'output/advertisements/' + self.user.email + '_' + videoId + '_' + \
             str(self.init_time).replace(':', '-').replace(' ', '_') + '.json'
-        # self.__log_info(f"{videoId}_opened")
-        # we check whether a skip button is present
-        if len(self.driver.find_elements_by_xpath("//*[@class='ytp-ad-preview-container countdown-next-to-thumbnail']")) != 0:
-            # store the advertiser
-            advertisements[videoId].append(self.driver.find_element_by_xpath(
-                "//*[@class='ytp-ad-button ytp-ad-visit-advertiser-button ytp-ad-button-link']").text)
-            # wait until we can skip
-            time.sleep(5)
-            # if the ad is only 5 seconds long, it is already over now, so have to check whether the button is still there before we click it
-            skip_button = self.driver.find_element_by_xpath("//*[@class='ytp-ad-skip-button ytp-button']")
-            if skip_button.is_displayed():
-                skip_button.click()
-        # wait again, for second ad that might appear
-        time.sleep(1)
-        # check for presence of second ad
-        if len(self.driver.find_elements_by_xpath("//*[@class='ytp-ad-preview-container countdown-next-to-thumbnail']")) != 0:
-            advertisements[videoId].append(self.driver.find_element_by_xpath(
-                "//*[@class='ytp-ad-button ytp-ad-visit-advertiser-button ytp-ad-button-link']").text)
-            time.sleep(5)
-            skip_button = self.driver.find_element_by_xpath("//*[@class='ytp-ad-skip-button ytp-button']")
-            if skip_button.is_displayed():
-                skip_button.click()
+
+        async def handle_ad() -> bool:
+            adXp = "//*[@class='ytp-ad-preview-container countdown-next-to-thumbnail']"
+            if len(self.driver.find_elements_by_xpath(adXp)) == 0:
+                return False
+            ad = self.driver.find_element_by_xpath(adXp).text
+            self.log.info('{email} - saw ad ({ad}) when watching {video}', email=self.user.email, video=videoId, ad=ad)
+            advertisements[videoId].append(ad)
+            try:
+                self.wait_for_visible('*.ytp-ad-skip-button.ytp-button').click()
+            except TimeoutException:
+                return False
+
+        while await handle_ad():
+            await asyncio.sleep(1)
 
         # measure for how long we are watching the actual video
         start_time = time.time()
@@ -344,7 +380,7 @@ class Crawler:
         # to make sure that every video is watched long enough
         # watch_time = duration if duration < 300 else 300 if duration/3 < 300 else duration/3
         watch_time = duration if duration < 300 else 300
-        print(watch_time)
+
         # let the asynchronous manager know that now other videos can be started
         await asyncio.sleep(watch_time)
         # todo replace with seq logging
@@ -359,6 +395,10 @@ class Crawler:
             'watch_time': time.time()-start_time
         }
         self.store.save(seshPath / watch_time_log_file, watch_time)
+
+        self.log.info('{email} - finished watching {watch_time}s of video {video}',
+                      email=self.user.email, video=videoId, watch_time=watch_time['watch_time'])
+
         self.driver.switch_to.window(current_tab)
         # self.__log_info(f'{videoId}_watched')
         self.driver.close()
@@ -453,6 +493,7 @@ class Crawler:
             str(self.init_time).replace(':', '-').replace(' ', '_') + '.json'
         # upload the information as a blob
         self.store.save(seshPath / filename, feed_info)
+        self.log.info('{email} - scanned feed', email=self.user.email)
 
     def __save_cookies(self):
         """saves all cookies
@@ -487,7 +528,7 @@ class Crawler:
         return localImagePath
 
     # easy method to save screenshots for headless mode
-    async def __log_info(self, name: str, error: str = None):
+    async def __log_driver_status(self, name: str, error: str = None):
         wd = self.driver
 
         seshPath = self.path_session()
@@ -510,6 +551,8 @@ class Crawler:
 
         print(f'driver {wd.current_url} - {name} - {seshPath}')
         if(error != None):
+            self.log.error('{email} - expereinced error ({error}) at {url} when ({phase})',
+                           email=self.user.email, error=error, url=wd.current_url, phase={name})
             await self.bot.msg(f'{self.user.email} expereinced error ({error}) at {wd.current_url} when ({name})', localImagePath)
 
         os.remove(localImagePath)

--- a/UserScrape/data.py
+++ b/UserScrape/data.py
@@ -1,32 +1,56 @@
 import pandas as pd
 from cfg import UserCfg
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Dict, Tuple, Iterable, Any
+from pandas.core.series import Series
+
 
 @dataclass
-class SeedVideo:
-    video_id:str
-    video_title:str
+class BasicVideo:
+    video_id: str
+    video_title: str
     channel_id: str
     channel_title: str
-    ideology:str
-    ideology_rank:int
-
-    
-
-def load_all_seeds() -> pd.DataFrame:
-    # this SQL generates this file https://github.com/markledwich2/YouTubeNetworks_Dataform/blob/master/sql/user_scrape_videos_to_watch.sql
-    all_seeds = pd.read_csv('https://pyt.blob.core.windows.net/data/results/user_scrape/video_seeds.csv.gz')
-    return all_seeds
-
-def seeds_for_user(user:UserCfg, all_seeds:pd.DataFrame, num:int=50):
-    user_df = all_seeds[all_seeds["IDEOLOGY"] == user.ideology]
-    user_videos = [SeedVideo(row.VIDEO_ID, row.VIDEO_TITLE, row.CHANNEL_ID, row.CHANNEL_TITLE, row.IDEOLOGY, row.IDEOLOGY_RANK) for i, row in user_df.iterrows() ]
-    return user_videos
+    ideology: str
 
 
+@dataclass
+class SeedVideo(BasicVideo):
+    ideology_rank: int
+
+# todo: this list should be queries directly form snowflake. cheaper during development to start like this
 
 
+def load_test_videos() -> List[BasicVideo]:
+    """gets the top 5 videos in the last 7 days for each ideology (distinct channels)"""
+    # this SQL generates this file https://github.com/markledwich2/YouTubeNetworks_Dataform/blob/master/sql/user_scrape_tests.sql
+    # todo: this list should be queries directly form snowflake. cheaper during development to start like this
+    df = pd.read_csv('https://pyt.blob.core.windows.net/data/results/user_scrape/video_seeds.csv.gz')
+    test_videos = [
+        BasicVideo(row.VIDEO_ID, row.VIDEO_TITLE, row.CHANNEL_ID, row.CHANNEL_TITLE, row.IDEOLOGY)
+        for i, row in df.iterrows()
+    ]
+    return test_videos
 
 
-    
+def load_seed_videos(num: int = 50) -> Dict[str, List[SeedVideo]]:
+    """a list of videos to seed user history with. Random videos proportional to views spread across channels in each ideology group
+
+    Keyword Arguments:
+        num {int} -- the number of videos to return per-ideology (default: {50})
+
+    Returns:
+        Dict[str, List[SeedVideo]] -- the seed videos grouped by ideology
+    """
+
+    def videos(rows: Iterable[Any]):
+        return [
+            SeedVideo(row.VIDEO_ID, row.VIDEO_TITLE, row.CHANNEL_ID, row.CHANNEL_TITLE, row.IDEOLOGY, row.IDEOLOGY_RANK)
+            for i, row in rows
+        ][0:num]
+
+    # this SQL generates this file https://github.com/markledwich2/YouTubeNetworks_Dataform/blob/master/sql/user_scape_seeds.sql
+    # todo: this list should be queries directly form snowflake. cheaper during development to start like this
+    df = pd.read_csv('https://pyt.blob.core.windows.net/data/results/user_scrape/video_seeds.csv.gz')
+    d = df.groupby(['IDEOLOGY']).apply(lambda g: videos(g.iterrows())).to_dict()
+    return d

--- a/UserScrape/discord_bot.py
+++ b/UserScrape/discord_bot.py
@@ -38,7 +38,7 @@ class DiscordBot():
             self.codes[email] = code
             await ctx.channel.send(f'Thanks for providing the validation code for {email}. Scraping resumes!')
 
-    async def request_code(self, user: UserCfg, msg:str=None, file:PurePath=None):
+    async def request_code(self, user: UserCfg, msg: str = None, file: PurePath = None):
         await self.bot.wait_until_ready()
         self.codes[user.email] = None
         channel = self.channel()
@@ -63,7 +63,7 @@ class DiscordBot():
             raise EnvironmentError(f'channel {self.channel_id} not found')
         return channel
 
-    async def msg(self, msg:str, localFile:PurePath=None):
+    async def msg(self, msg: str, localFile: PurePath = None):
         channel = self.channel()
         if(localFile != None):
             await channel.send(msg, file=discord.File(localFile.as_posix()))
@@ -71,8 +71,8 @@ class DiscordBot():
             await channel.send(msg)
 
     async def start_in_backround(self):
-        asyncio.create_task(self.bot.start(self.token)) # run as a background task and return once it has been started
+        asyncio.create_task(self.bot.start(self.token))  # run as a background task and return once it has been started
         await self.bot.wait_until_ready()
 
     async def close(self):
-        self.bot.close()
+        await self.bot.close()

--- a/UserScrape/log.py
+++ b/UserScrape/log.py
@@ -1,0 +1,36 @@
+import seqlog
+import logging
+import json
+
+
+def configure_log(url: str, env='Debug', experiment_id=None):
+    seqlog.configure_from_dict({
+        'version': 1,
+        'disable_existing_loggers': True,
+        'root': {
+            'level': 'WARN',
+            'handlers': ['console']
+        },
+        'loggers': {
+            'seq': {
+                'level': 'INFO',
+                'handlers': ['seq']
+            }
+        },
+        'handlers': {
+            'console': {
+                'class': 'seqlog.structured_logging.ConsoleStructuredLogHandler'
+            },
+            'seq': {
+                'class': 'seqlog.structured_logging.SeqLogHandler',
+                'server_url': url,
+                'batch_size': 1
+            }
+        }
+    })
+
+    seqlog.set_global_log_properties(
+        app="UserScrape",
+        env=env,
+        experiment=experiment_id
+    )

--- a/UserScrape/requirements.txt
+++ b/UserScrape/requirements.txt
@@ -6,3 +6,5 @@ dataclasses_json
 dataclasses_jsonschema
 pandas
 discord.py
+seqlog
+shortuuid

--- a/UserScrape/store.py
+++ b/UserScrape/store.py
@@ -7,13 +7,14 @@ from typing import Union
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import PublicAccess
 
+
 class BlobStore:
     def __init__(self, cs: str, containerName: str):
         self.cs = cs
         self.container = ContainerClient.from_connection_string(
             cs, containerName)
 
-    def ensure_exits(self, public_access:PublicAccess = None):
+    def ensure_exits(self, public_access: PublicAccess = None):
         """creates the container if it doesn't exist"""
         try:
             props = self.container.get_container_properties()
@@ -21,7 +22,7 @@ class BlobStore:
             self.container.create_container(public_access=public_access)
         except BaseException as e:
             raise e
-    
+
     def save(self, path: PurePath, content: Union[str, dict]):
         """Saves text content to a blob with the given path. W
 
@@ -30,11 +31,11 @@ class BlobStore:
             content {Union[str, dict]} -- str content will be saved as is, dict will be serialized to json
         """
         txt = json.dumps(content) if isinstance(content, dict) else content
-            
+
         localPath = Path(tempfile.gettempdir()) / path
         localPath.parent.mkdir(parents=True, exist_ok=True)
         with open(localPath, "w", encoding="utf-8") as w:
-           w.write(txt)
+            w.write(txt)
         self.save_file(localPath, path)
         os.remove(localPath)
 
@@ -53,7 +54,4 @@ class BlobStore:
 
     def load_dic(self, path: PurePath):
         txt = self.load(path)
-        return json.loads(txt)
-
-
-        
+        return json.loads(txt) if txt else None

--- a/UserScrape/userscrape.schema.json
+++ b/UserScrape/userscrape.schema.json
@@ -4,7 +4,8 @@
     "data_storage_cs",
     "users",
     "headless",
-    "discord"
+    "discord",
+    "seqUrl"
   ],
   "properties": {
     "data_storage_cs": {
@@ -28,6 +29,14 @@
     "discord": {
       "$ref": "#/definitions/DiscordCfg",
       "description": "configuration for the discord bot used to request user validation"
+    },
+    "seqUrl": {
+      "type": "string",
+      "examples": [
+        "http://log.recfluence.net/",
+        "http://localhost:5341/"
+      ],
+      "description": "url of your seq instance"
     }
   },
   "description": "UserScrape configuration",


### PR DESCRIPTION
- Added seq logging. It will work without, but it's worth installing https://datalust.co/seq
![image](https://user-images.githubusercontent.com/17095341/82877687-dd416400-9f7d-11ea-81d0-2dcbcf88ab1e.png)
   - each run has an experiment id, so you can filter with that in the logs
   - scraping always logs the account's email so you can filter to that
   - depending on where the error occurs, the full stack trace will be in the logs
- Get recommendations for top 5 videos in the last 7 days for each ideology (distinct channels)
https://github.com/markledwich2/YouTubeNetworks_Dataform/blob/master/sql/user_scrape_tests.sql

- When a video is unavailable collect the reasons and store that info